### PR TITLE
Fix typo for config_file option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can also use a preexisting uWSGI configuration like so:
 uwsgi_service "myapp" do
   home_path "/var/www/app"
   pid_path "/var/run/uwsgi-app.pid"
-  config_path "/etc/uwsgi/myapp.yaml"
+  config_file "/etc/uwsgi/myapp.yaml"
   config_type :yaml
 end
 ```


### PR DESCRIPTION
The option to set a config file is called `config_file` but was shown as `config_path` in the example in the readme. Fixed.
