### PR TITLE
allow socket for unix:/

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Definitions
 -  `:config_type`       - configuration file type, default to `:ini`
 -  `:host`              - hostname to run uWSGI on, default to `"127.0.0.1"`
 -  `:port`              - port number to run uWSGI on, default to `8080`
+-  `:socket`            - socket to listen on, default to `#{host}:#{port}`
 -  `:worker_processes`  - number of uWSGI workers, default to `2`, should probably be relative to the number of CPUs
 -  `:app`               - app to run on uwsgi, passed to --module parameted of uWSGI, default to `"main:app"`
 -  `:uid`               - user-id to run uwsgi under, default to `"www-data"`

--- a/definitions/uwsgi_service.rb
+++ b/definitions/uwsgi_service.rb
@@ -3,6 +3,7 @@ define :uwsgi_service,
     :pid_path => "/var/run/uwsgi-app.pid",
     :host => "127.0.0.1",
     :port => 8080,
+    :socket => nil,
     :worker_processes => 2,
     :app => "main:app",
     :uid => "www-data",
@@ -29,8 +30,7 @@ define :uwsgi_service,
   # need to assign params to local vars as we can't pass params to nested definitions
   home_path = params[:home_path]
   pid_path = params[:pid_path]
-  host = params[:host]
-  port = params[:port]
+  socket = params[:socket] || "#{params[:host]}:#{params[:port]}"
   worker_processes = params[:worker_processes]
   app = params[:app]
   uid = params[:uid]
@@ -62,8 +62,7 @@ define :uwsgi_service,
     options ({
       :home_path => home_path,
       :pid_path => pid_path,
-      :host => host,
-      :port => port,
+      :socket => socket,
       :worker_processes => worker_processes,
       :app => app,
       :uid => uid,

--- a/templates/default/sv-uwsgi-run.erb
+++ b/templates/default/sv-uwsgi-run.erb
@@ -3,7 +3,7 @@
 UWSGI=<%= @options[:uwsgi_bin] %>
 ROOT=<%= @options[:home_path] %>
 PID=<%= @options[:pid_path] %>
-SOCKET=<%= @options[:host] %>:<%= @options[:port] %>
+SOCKET=<%= @options[:socket] %>
 
 if [ -f $PID ]; then kill -9 `cat $PID`; rm $PID; fi
 


### PR DESCRIPTION
This allows the user to specify the socket ie:

```ruby
uwsgi_service 'myapp' do
  home_path '/var/www/app'
  pid_path '/var/run/uwsgi-app.pid'
  socket '/var/myapp.sock'
  worker_processes 2
  app 'flask:app'
end
```

if not specified, it will default to `host:port` as before